### PR TITLE
Artist model

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ group :development, :test do
   gem 'launchy'
   gem 'pry'
   gem 'simplecov'
+  gem 'shoulda-matchers'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -160,6 +160,8 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    shoulda-matchers (4.0.1)
+      activesupport (>= 4.2.0)
     simplecov (0.16.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -206,6 +208,7 @@ DEPENDENCIES
   rails (~> 5.1.7)
   rspec-rails
   sass-rails (~> 5.0)
+  shoulda-matchers
   simplecov
   tzinfo-data
   uglifier (>= 1.3.0)

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -1,0 +1,2 @@
+class Artist < ApplicationRecord
+end

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -1,3 +1,5 @@
 class Artist < ApplicationRecord
+  has_many :songs
+  
   validates_presence_of :name
 end

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -1,2 +1,3 @@
 class Artist < ApplicationRecord
+  validates_presence_of :name
 end

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -1,5 +1,9 @@
 class Artist < ApplicationRecord
   has_many :songs
-  
+
   validates_presence_of :name
+
+  def average_song_length
+    songs.average(:length).to_i
+  end
 end

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -4,6 +4,6 @@ class Artist < ApplicationRecord
   validates_presence_of :name
 
   def average_song_length
-    songs.average(:length).to_i
+    songs.average(:length)
   end
 end

--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -1,2 +1,3 @@
 class Song < ApplicationRecord
+  belongs_to :artist
 end

--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -1,3 +1,7 @@
 class Song < ApplicationRecord
   belongs_to :artist
+
+  def self.song_count
+    count
+  end
 end

--- a/db/migrate/20190501162126_create_artists.rb
+++ b/db/migrate/20190501162126_create_artists.rb
@@ -1,0 +1,9 @@
+class CreateArtists < ActiveRecord::Migration[5.1]
+  def change
+    create_table :artists do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190501164840_add_artists_to_songs.rb
+++ b/db/migrate/20190501164840_add_artists_to_songs.rb
@@ -1,0 +1,5 @@
+class AddArtistsToSongs < ActiveRecord::Migration[5.1]
+  def change
+    add_reference :songs, :artist, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190430172324) do
+ActiveRecord::Schema.define(version: 20190501162126) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "artists", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "songs", force: :cascade do |t|
     t.string "title"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190501162126) do
+ActiveRecord::Schema.define(version: 20190501164840) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,6 +27,9 @@ ActiveRecord::Schema.define(version: 20190501162126) do
     t.integer "play_count"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "artist_id"
+    t.index ["artist_id"], name: "index_songs_on_artist_id"
   end
 
+  add_foreign_key "songs", "artists"
 end

--- a/spec/features/songs/index_spec.rb
+++ b/spec/features/songs/index_spec.rb
@@ -2,8 +2,9 @@ require 'rails_helper'
 
 RSpec.describe 'songs index page', type: :feature do
   it 'user can see all songs' do
-    song_1 = Song.create(title: "Don't Stop Believin'", length: 303, play_count: 123456)
-    song_2 = Song.create(title: "Never Gonna Give You Up", length: 253, play_count: 987654321)
+    artist = Artist.create(name: "Placeholder")
+    song_1 = artist.songs.create(title: "Don't Stop Believin'", length: 303, play_count: 123456)
+    song_2 = artist.songs.create(title: "Never Gonna Give You Up", length: 253, play_count: 987654321)
 
     visit '/songs'
 

--- a/spec/models/artist_spec.rb
+++ b/spec/models/artist_spec.rb
@@ -5,4 +5,8 @@ RSpec.describe Artist, type: :model do
     it { should validate_presence_of :name }
   end
 
+  describe 'relationships' do
+    it { should have_many :songs}
+  end
+
 end

--- a/spec/models/artist_spec.rb
+++ b/spec/models/artist_spec.rb
@@ -9,4 +9,14 @@ RSpec.describe Artist, type: :model do
     it { should have_many :songs}
   end
 
+  describe 'instance methods' do
+    it '.average_song_length' do
+      talking_heads = Artist.create!(name: 'Talking Heads')
+      she_was = talking_heads.songs.create!(title: 'And She Was', length: 234, play_count: 34)
+      wild_life = talking_heads.songs.create!(title: 'Wild Wild Life', length: 456, play_count: 45)
+
+      expect(talking_heads.average_song_length).to eq(345)
+    end
+  end
+
 end

--- a/spec/models/artist_spec.rb
+++ b/spec/models/artist_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+RSpec.describe Artist, type: :model do
+  describe 'validations' do
+    it { should validate_presence_of :name }
+  end
+
+end

--- a/spec/models/song_spec.rb
+++ b/spec/models/song_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+RSpec.describe Song, type: :model do
+  describe 'relationship' do
+    it {should belong_to :artist}
+  end
+
+end

--- a/spec/models/song_spec.rb
+++ b/spec/models/song_spec.rb
@@ -5,4 +5,15 @@ RSpec.describe Song, type: :model do
     it {should belong_to :artist}
   end
 
+  describe 'class methods' do
+    it '.song_count' do
+      prince = Artist.create!(name: 'Prince')
+      talking_heads = Artist.create!(name: 'Talking Heads')
+      rasperry_beret = prince.songs.create!(title: 'Raspberry Beret', length: 234, play_count: 34)
+      wild_life = talking_heads.songs.create!(title: 'Wild Wild Life', length: 456, play_count: 45)
+
+      expect(Song.song_count).to eq(2)
+    end
+  end
+
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -61,3 +61,10 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 end
+
+Shoulda::Matchers.configure do |config|
+	config.integrate do |with|
+		with.test_framework :rspec
+		with.library :rails
+	end
+end


### PR DESCRIPTION
This PR brings in the Artist model to our Setlist app. An Artist has a one-to-many relationship with Songs, an Artist has multiple Songs, but a Song has only one Artist (in this world). 
We implemented Shoulda Matchers to allow us to perform efficient Model testing. This allowed quick and easy testing of Validation, Associations, and methods on our Artist and Song models. 
We also added the AddArtistsToSong migration, updating our DB schema to include foreign keys for Artists inside of Songs.
We updated our view #index to contain tests looking for Songs under their respective Artists as well.
Our Artist now has an #average_song_length method, which takes all Songs that it is connected to and averages (ActiveRecord magic!) the length.